### PR TITLE
Readds the Clown Car to traitor uplink + Clown Car reworks

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1525,18 +1525,20 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 	restricted_roles = list("Clown")
 
-/*
+
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"
 	desc = "The Clown Car is the ultimate transportation method for any worthy clown! \
 			Simply insert your bikehorn and get in, and get ready to have the funniest ride of your life! \
 			You can ram any spacemen you come across and stuff them into your car, kidnapping them and locking them inside until \
 			someone saves them or they manage to crawl out. Be sure not to ram into any walls or vending machines, as the springloaded seats \
-			are very sensetive. Now with our included lube defense mechanism which will protect you against any angry shitcurity!"
+			are very sensetive. Now with our included lube defense mechanism which will protect you against any angry shitcurity!\
+			Can be emagged for EXTRA FUN!"
 	item = /obj/vehicle/sealed/car/clowncar
 	cost = 15
 	restricted_roles = list("Clown")
-*/
+
+
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -49,6 +49,8 @@
 	if(isliving(M))
 		if(ismegafauna(M))
 			return
+		if(occupant_amount() >= max_occupants)
+			return
 		var/mob/living/L = M
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
@@ -70,8 +72,17 @@
 	initialize_controller_action_type(/datum/action/vehicle/sealed/RollTheDice, VEHICLE_CONTROL_DRIVE)
 
 /obj/vehicle/sealed/car/clowncar/Destroy()
-  playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)
-  return ..()
+	playsound(src, 'sound/vehicles/clowncar_fart.ogg', 100)
+	visible_message("<span class='danger'>\The [src] explodes in a shower of lube, throwing out all [occupant_amount()] people!</span>")
+	explosion(loc,0,0,1,2,FALSE,FALSE,1,FALSE,FALSE)
+	var/datum/reagents/R = new/datum/reagents(300)
+	R.my_atom = src
+	R.add_reagent("lube", 300)
+	var/datum/effect_system/smoke_spread/chem/smoke = new()
+	smoke.set_up(R, 4)
+	smoke.attach(src)
+	smoke.start()
+	return ..()
 
 /obj/vehicle/sealed/car/clowncar/after_move(direction)
 	. = ..()

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -51,7 +51,7 @@
 	if(randomstep)
 		var/turf/target_turf = get_step(exit_location(M), pick(GLOB.cardinals))
 		M.throw_at(target_turf, 5, 10)
-		
+
 	if(!silent)
 		M.visible_message("<span class='notice'>[M] drops out of \the [src]!</span>")
 	return TRUE
@@ -84,8 +84,7 @@
 	inserted_key = null
 
 /obj/vehicle/sealed/Destroy()
-	DumpMobs()
-	explosion(loc, 0, 1, 2, 3, 0)
+	DumpMobs(TRUE)
 	return ..()
 
 /obj/vehicle/sealed/proc/DumpMobs(randomstep = TRUE)
@@ -102,7 +101,7 @@
 			if(iscarbon(i))
 				var/mob/living/carbon/C = i
 				C.Knockdown(40)
-			
-			
+
+
 /obj/vehicle/sealed/AllowDrop()
 	return FALSE


### PR DESCRIPTION
:cl: BurgerBB
add: Readds the clown car to traitor uplink
tweak: Clown car now spews smoke lube when destroyed.
balance: Clown car explosion no longer removes limbs.
fix: Fixed the clown car not respecting capacity varedits.
/:cl:
