### PR TITLE
Added toggle-able rainbow lightup shoes and functional heelys to maint loot

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -109,5 +109,7 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/reagent_containers/pill/floorpill = 1,
 	/obj/item/storage/daki = 3, //VERY IMPORTANT CIT CHANGE - adds bodypillows to maint
 	/obj/item/storage/pill_bottle/penis_enlargement = 2,
+	/obj/item/clothing/shoes/wheelys = 1,
+	/obj/item/clothing/shoes/kindleKicks = 1,
 	"" = 3
 	))


### PR DESCRIPTION
:cl: SkullyRoberts
add: added /obj/item/clothing/shoes/wheelys and /obj/item/clothing/shoes/kindleKicks as rare maint loot
/:cl:

[why]: Wheelys are shoes that can be "transformed" into a ridden scooter at any point (functionally) in order to simulate riding on the wheels of a pair of heelys.

KindleKicks are shoes that can be toggled to light up random colors.

Because they are two fun items that we have had for a while and function fine, but players currently have no way of actually acquiring them in game. This PR changes that.
