### PR TITLE
Meteor Sats not exclusive to station goal

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -873,8 +873,7 @@
 /datum/supply_pack/engineering/shield_sat
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. Contains three Shield Generator Satellites."
-	cost = 3000
-	special = TRUE
+	cost = 4000
 	contains = list(
 					/obj/machinery/satellite/meteor_shield,
 					/obj/machinery/satellite/meteor_shield,
@@ -886,8 +885,7 @@
 /datum/supply_pack/engineering/shield_sat_control
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
-	cost = 5000
-	special = TRUE
+	cost = 4000
 	contains = list(/obj/item/circuitboard/computer/sat_control)
 	crate_name= "shield control board crate"
 


### PR DESCRIPTION
:cl: Sishen1542
tweak: Adds the ability to buy meteor sats independently of station goal
/:cl:

[why]: Adds the ability to buy meteor sats independently of station goal so in the case of RNG fuckery during secret the station doesn't get tunguska'd to kingdom come.

Also changes the console crate to be the same price as a crate of sats.
