### PR TITLE
Adds traits: Friendly and empathy

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -72,6 +72,8 @@
 #define	TRAIT_CROCRIN_IMMUNE    "crocin_immune"
 #define TRAIT_NYMPHO			"nymphomania"
 #define TRAIT_MASO              "masochism"
+#define TRAIT_EMPATH			"empath"
+#define TRAIT_FRIENDLY			"friendly"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -125,3 +125,11 @@
 /datum/mood_event/surgery
 	description = "<span class='boldwarning'>HE'S CUTTING ME OPEN!!</span>\n"
 	mood_change = -8
+
+/datum/mood_event/sad_empath
+	description = "<span class='warning'>Someone seems upset...</span>\n"
+	mood_change = -2
+	timeout = 600
+
+/datum/mood_event/sad_empath/add_effects(mob/sadtarget)
+	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -75,3 +75,27 @@
 	description = "<span class='nicegreen'>There is something soothing about this music.</span>\n"
 	mood_change = 3
 	timeout = 600
+
+/datum/mood_event/betterhug
+	description = "<span class='nicegreen'>Someone was very nice to me.</span>\n"
+	mood_change = 3
+	timeout = 3000
+
+/datum/mood_event/betterhug/add_effects(mob/friend)
+	description = "<span class='nicegreen'>[friend.name] was very nice to me.</span>\n"
+
+/datum/mood_event/besthug
+	description = "<span class='nicegreen'>Someone is great to be around, they make me feel so happy!</span>\n"
+	mood_change = 5
+	timeout = 3000
+
+/datum/mood_event/besthug/add_effects(mob/friend)
+	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.p_they()] makes me feel so happy!</span>\n"
+
+/datum/mood_event/happy_empath
+	description = "<span class='warning'>Someone seems happy!</span>\n"
+	mood_change = 2
+	timeout = 600
+
+/datum/mood_event/happy_empath/add_effects(var/mob/happytarget)
+	description = "<span class='warning'>[happytarget.name]'s happiness is infectious!</span>\n"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -35,6 +35,14 @@
 	lose_text = "<span class='danger'>You no longer feel like drinking would ease your pain.</span>"
 	medical_record_text = "Patient has unusually efficient liver metabolism and can slowly regenerate wounds by drinking alcoholic beverages."
 
+/datum/quirk/empath
+	name = "Empath"
+	desc = "Whether it's a sixth sense or careful study of body language, it only takes you a quick glance at someone to understand how they feel."
+	value = 2
+	mob_trait = TRAIT_EMPATH
+	gain_text = "<span class='notice'>You feel in tune with those around you.</span>"
+	lose_text = "<span class='danger'>You feel isolated from others.</span>"
+
 /datum/quirk/freerunning
 	name = "Freerunning"
 	desc = "You're great at quick moves! You can climb tables more quickly."
@@ -42,6 +50,15 @@
 	mob_trait = TRAIT_FREERUNNING
 	gain_text = "<span class='notice'>You feel lithe on your feet!</span>"
 	lose_text = "<span class='danger'>You feel clumsy again.</span>"
+
+/datum/quirk/friendly
+	name = "Friendly"
+	desc = "You give the best hugs, especially when you're in the right mood."
+	value = 1
+	mob_trait = TRAIT_FRIENDLY
+	gain_text = "<span class='notice'>You want to hug someone.</span>"
+	lose_text = "<span class='danger'>You no longer feel compelled to hug others.</span>"
+	mood_quirk = TRUE
 
 /datum/quirk/jolly
 	name = "Jolly"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -277,6 +277,12 @@
 			M.visible_message("<span class='notice'>[M] gives [H] a pat on the head to make [p_them()] feel better!</span>", \
 						"<span class='notice'>You give [H] a pat on the head to make [p_them()] feel better!</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "headpat", /datum/mood_event/headpat)
+			if(M.has_trait(TRAIT_FRIENDLY))
+				GET_COMPONENT_FROM(mood, /datum/component/mood, M)
+				if (mood.sanity >= SANITY_GREAT)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
+				else if (mood.sanity >= SANITY_DISTURBED)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)
 			if(H.dna.species.can_wag_tail(H))
 				if("tail_human" in pref_species.default_features)
 					if(H.dna.features["tail_human"] == "None")
@@ -306,6 +312,12 @@
 			M.visible_message("<span class='notice'>[M] hugs [src] to make [p_them()] feel better!</span>", \
 						"<span class='notice'>You hug [src] to make [p_them()] feel better!</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "hug", /datum/mood_event/hug)
+			if(M.has_trait(TRAIT_FRIENDLY))
+				GET_COMPONENT_FROM(mood, /datum/component/mood, M)
+				if (mood.sanity >= SANITY_GREAT)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/besthug, M)
+				else if (mood.sanity >= SANITY_DISTURBED)
+					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "friendly_hug", /datum/mood_event/betterhug, M)
 
 		AdjustStun(-60)
 		AdjustKnockdown(-60)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -281,6 +281,27 @@
 			if(91.01 to INFINITY)
 				msg += "[t_He] [t_is] a shitfaced, slobbering wreck.\n"
 
+	if(isliving(user))
+		var/mob/living/L = user
+		if(src != user && L.has_trait(TRAIT_EMPATH) && !appears_dead)
+			if (a_intent != INTENT_HELP)
+				msg += "[t_He] seem[p_s()] to be on guard.\n"
+			if (getOxyLoss() >= 10)
+				msg += "[t_He] seem[p_s()] winded.\n"
+			if (getToxLoss() >= 10)
+				msg += "[t_He] seem[p_s()] sickly.\n"
+			GET_COMPONENT_FROM(mood, /datum/component/mood, src)
+			if(mood.sanity <= SANITY_DISTURBED)
+				msg += "[t_He] seem[p_s()] distressed.\n"
+				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "empath", /datum/mood_event/sad_empath, src)
+			if(mood.mood >= 5) //So roundstart people aren't all "happy"
+				msg += "[t_He] seem[p_s()] to have had something nice happen to them recently.\n"
+				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "empathH", /datum/mood_event/happy_empath, src)
+			if (has_trait(TRAIT_BLIND))
+				msg += "[t_He] appear[p_s()] to be staring off into space.\n"
+			if (has_trait(TRAIT_DEAF))
+				msg += "[t_He] appear[p_s()] to not be responding to noises.\n"
+
 	msg += "</span>"
 
 	if(!appears_dead)

--- a/modular_citadel/code/datums/mood_events/generic_positive_events.dm
+++ b/modular_citadel/code/datums/mood_events/generic_positive_events.dm
@@ -24,7 +24,7 @@
 	description = "<font color = #780A53><i><b>I came!</font></i></b>" //funny meme haha
 	mood_change = 3
 	timeout = 1000
-	
+
 /datum/mood_event/fedpred
 	description = "<span class='nicegreen'>I've devoured someone!</span>\n"
 	mood_change = 3

--- a/modular_citadel/code/datums/mood_events/moodular.dm
+++ b/modular_citadel/code/datums/mood_events/moodular.dm
@@ -7,12 +7,7 @@
 	if(mood)
 		mood.add_event("hugbox", /datum/mood_event/hugbox)
 
-// headpats (IMPORTANT)
-/mob/living/carbon/help_shake_act(mob/living/carbon/M)
-	. = ..()
-	GET_COMPONENT_FROM(mood, /datum/component/mood, src)
-	if(mood)
-		mood.add_event("headpat", /datum/mood_event/headpat)
+//Removed headpats here, duplicate code?
 
 // plush petting
 /obj/item/toy/plush/attack_self(mob/user)


### PR DESCRIPTION
[Changelogs]: Original PR: https://github.com/Citadel-Station-13/Citadel-Station-13/pull/8508

Adds the traits Friendly and Empathy from: tgstation/tgstation#43651

One edit on my part regarding the functionality; adds a bonus to mood for happy people, otherwise functions the same.

However, there's a runtime that occurs for headpats, looking over the code there seems to be two headpat add_events. One in moodular.dm (modular cit) and another in carbon_defence.dm . I removed the code in moodular, and headpats still seem to work, but please check this.

Add: Traits; Friendly and Empathy
Tweak: made headpat add_event occur only once.

Why:
Citadel meta is all about the affection, now people who really want to powergame can get ahead by giving even better pets.

Or more seriously; Giving the option to give better affection plays into character expression.