### PR TITLE
Adds clown shoe waddle, waddle dampeners (TM), and other important tweaks

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -14,7 +14,7 @@
 	var/turf/open/T = get_turf(parent)
 	if(!istype(T))
 		return
-	
+
 	var/mob/living/LM = parent
 	var/v = volume
 	var/e = e_range
@@ -22,7 +22,7 @@
 		if (LM.lying && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
 			playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 		return
-	
+
 	if(iscarbon(LM))
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
@@ -31,18 +31,18 @@
 			v /= 2
 			e -= 5
 	steps++
-	
-	if(steps >= 3)
+
+	if(steps >= 2)
 		steps = 0
-	
+
 	else
 		return
-	
+
 	if(prob(80) && !LM.has_gravity(T)) // don't need to step as often when you hop around
 		return
-		
+
 	//begin playsound shenanigans//
-	
+
 	//for barefooted non-clawed mobs like monkeys
 	if(isbarefoot(LM))
 		playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
@@ -50,19 +50,19 @@
 			TRUE,
 			GLOB.barefootstep[T.barefootstep][3] + e)
 		return
-	
+
 	//for xenomorphs, dogs, and other clawed mobs
 	if(isclawfoot(LM))
 		if(isalienadult(LM)) //xenos are stealthy and get quieter footsteps
 			v /= 3
 			e -= 5
-		
+
 		playsound(T, pick(GLOB.clawfootstep[T.clawfootstep][1]),
 				GLOB.clawfootstep[T.clawfootstep][2] * v,
 				TRUE,
 				GLOB.clawfootstep[T.clawfootstep][3] + e)
 		return
-	
+
 	//for megafauna and other large and imtimidating mobs such as the bloodminer
 	if(isheavyfoot(LM))
 		playsound(T, pick(GLOB.heavyfootstep[T.heavyfootstep][1]),
@@ -70,12 +70,12 @@
 				TRUE,
 				GLOB.heavyfootstep[T.heavyfootstep][3] + e)
 		return
-	
+
 	//for slimes
-	if(isslime(LM)) 
+	if(isslime(LM))
 		playsound(T, 'sound/effects/footstep/slime1.ogg', 15 * v)
 		return
-		
+
 	//for (simple) humanoid mobs (clowns, russians, pirates, etc.)
 	if(isshoefoot(LM))
 		if(!ishuman(LM))
@@ -87,17 +87,17 @@
 		if(ishuman(LM)) //for proper humans, they're special
 			var/mob/living/carbon/human/H = LM
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			
+
 			if (H.dna.features["taur"] == "Naga" || H.dna.features["taur"] == "Tentacle") //are we a naga or tentacle taur creature
 				playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 				return
-			
+
 			if(H.shoes || feetCover) //are we wearing shoes
 				playsound(T, pick(GLOB.footstep[T.footstep][1]),
 					GLOB.footstep[T.footstep][2] * v,
 					TRUE,
 					GLOB.footstep[T.footstep][3] + e)
-			
+
 			if((!H.shoes && !feetCover)) //are we NOT wearing shoes
 				playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
 					GLOB.barefootstep[T.barefootstep][2] * v,

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -67,13 +67,15 @@
 	SEND_SIGNAL(t_loc, COMSIG_TURF_MAKE_DRY, TURF_WET_WATER, TRUE, INFINITY)
 
 /obj/item/clothing/shoes/clown_shoes
-	desc = "The prankster's standard-issue clowning shoes. Damn, they're huge!"
+	desc = "The prankster's standard-issue clowning shoes. Damn, they're huge! Ctrl-click to toggle waddle dampeners."
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
 	slowdown = SHOES_SLOWDOWN+1
 	item_color = "clown"
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes/clown
+	var/datum/component/waddle
+	var/enabled_waddle = TRUE
 
 /obj/item/clothing/shoes/clown_shoes/Initialize()
 	. = ..()
@@ -81,13 +83,29 @@
 
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
 	. = ..()
+	if(slot == SLOT_SHOES && enabled_waddle)
+		waddle = user.AddComponent(/datum/component/waddling)
 	if(user.mind && user.mind.assigned_role == "Clown")
 		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "noshoes")
 
 /obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
 	. = ..()
+	QDEL_NULL(waddle)
 	if(user.mind && user.mind.assigned_role == "Clown")
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "noshoes", /datum/mood_event/noshoes)
+
+/obj/item/clothing/shoes/clown_shoes/CtrlClick(mob/living/user)
+	if(!isliving(user))
+		return
+	if(user.get_active_held_item() != src)
+		to_chat(user, "You must hold the [src] in your hand to do this.")
+		return
+	if (!enabled_waddle)
+		to_chat(user,"<span class='notice'>You switch off the waddle dampeners!</span>")
+		enabled_waddle = TRUE
+	else
+		to_chat(user,"<span class='notice'>You switch on the waddle dampeners!</span>")
+		enabled_waddle = FALSE
 
 /obj/item/clothing/shoes/clown_shoes/jester
 	name = "jester shoes"

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -267,6 +267,15 @@
 	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/gondola
 	foodtype = RAW | MEAT
 
+/obj/item/reagent_containers/food/snacks/meat/slab/penguin
+	name = "penguin meat"
+	desc = "A slab of penguin meat."
+	list_reagents = list("nutriment" = 2, "cooking_oil" = 3)
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/penguin
+	slice_path = /obj/item/reagent_containers/food/snacks/meat/rawcutlet/penguin
+	filling_color = "#B22222"
+	tastes = list("beef" = 1, "cod fish" = 1)
+
 ////////////////////////////////////// MEAT STEAKS ///////////////////////////////////////////////////////////
 
 
@@ -317,6 +326,10 @@
 /obj/item/reagent_containers/food/snacks/meat/steak/gondola
 	name = "gondola steak"
 	tastes = list("meat" = 1, "tranquility" = 1)
+
+/obj/item/reagent_containers/food/snacks/meat/steak/penguin
+	name = "penguin steak"
+	tastes = list("beef" = 1, "cod fish" = 1)
 
 //////////////////////////////// MEAT CUTLETS ///////////////////////////////////////////////////////
 
@@ -380,6 +393,11 @@
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
 	tastes = list("meat" = 1, "tranquility" = 1)
 
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet/penguin
+	name = "raw penguin cutlet"
+	cooked_type = /obj/item/reagent_containers/food/snacks/meat/cutlet/penguin
+	tastes = list("beef" = 1, "cod fish" = 1)
+
 //Cooked cutlets
 
 /obj/item/reagent_containers/food/snacks/meat/cutlet
@@ -419,3 +437,7 @@
 /obj/item/reagent_containers/food/snacks/meat/cutlet/gondola
 	name = "gondola cutlet"
 	tastes = list("meat" = 1, "tranquility" = 1)
+
+/obj/item/reagent_containers/food/snacks/meat/cutlet/penguin
+	name = "penguin cutlet"
+	tastes = list("beef" = 1, "cod fish" = 1)

--- a/code/modules/mob/living/simple_animal/friendly/penguin.dm
+++ b/code/modules/mob/living/simple_animal/friendly/penguin.dm
@@ -14,8 +14,13 @@
 	speak_chance = 1
 	turns_per_move = 10
 	icon = 'icons/mob/penguins.dmi'
+	butcher_results = list(/obj/item/organ/ears/penguin = 1, /obj/item/reagent_containers/food/snacks/meat/slab/penguin = 3)
 
 	do_footstep = TRUE
+
+/mob/living/simple_animal/pet/penguin/Initialize()
+	. = ..()
+	AddComponent(/datum/component/waddling)
 
 /mob/living/simple_animal/pet/penguin/emperor
 	name = "Emperor penguin"

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -94,3 +94,20 @@
 		H.dna.features["ears"] = "None"
 		H.dna.species.mutant_bodyparts -= "ears"
 		H.update_body()
+
+/obj/item/organ/ears/penguin
+	name = "penguin ears"
+	desc = "The source of a penguin's happy feet."
+	var/datum/component/waddle
+
+/obj/item/organ/ears/penguin/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
+	. = ..()
+	if(istype(H))
+		to_chat(H, "<span class='notice'>You suddenly feel like you've lost your balance.</span>")
+		waddle = H.AddComponent(/datum/component/waddling)
+
+/obj/item/organ/ears/penguin/Remove(mob/living/carbon/human/H,  special = 0)
+	. = ..()
+	if(istype(H))
+		to_chat(H, "<span class='notice'>Your sense of balance comes back to you.</span>")
+		QDEL_NULL(waddle)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -374,6 +374,7 @@
 #include "code\datums\components\swarming.dm"
 #include "code\datums\components\thermite.dm"
 #include "code\datums\components\uplink.dm"
+#include "code\datums\components\waddling.dm"
 #include "code\datums\components\wearertargeting.dm"
 #include "code\datums\components\wet_floor.dm"
 #include "code\datums\components\decals\blood.dm"


### PR DESCRIPTION
[Changelogs]: Ports waddle from /tg/.

:cl: Phi
add: Waddle is a thing again.
add: Clown shoes will now make the wearer waddle, can be toggled by ctrl-clicking to turn on/off WADDLE DAMPENERS (TM)
add: Penguins now waddle, and have a waddle organ which can be harvested
tweak: footstep sounds are more frequent (same as /tg/)
/:cl:

[why]: look at the funny clewn
