### PR TITLE
Record deaths into game.log

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -38,6 +38,7 @@
 
 	if(SSticker.HasRoundStarted())
 		SSblackbox.ReportDeath(src)
+		log_game("[key_name(src)] has died (BRUTE: [src.getBruteLoss()], BURN: [src.getFireLoss()], TOX: [src.getToxLoss()], OXY: [src.getOxyLoss()], CLONE: [src.getCloneLoss()]) ([AREACOORD(src)])")
 	if(is_devil(src))
 		INVOKE_ASYNC(is_devil(src), /datum/antagonist/devil.proc/beginResurrectionCheck, src)
 


### PR DESCRIPTION
[Changelogs]: 

:cl: Phi
admin: Deaths are now logged in game.log, with the damage taken, time and location.
/:cl:

[why]: wow it only took until now, the year of our lord 2019 for this to finally be added to the game log. Amazing.