### PR TITLE
Fixes ShadowBot notify command for the 3rd time

### DIFF
--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -84,7 +84,7 @@ GLOBAL_LIST(round_end_notifiees)
 	if(!SSticker.IsRoundInProgress() && SSticker.HasRoundStarted())
 		return "[sender.mention], the round has already ended!"
 	LAZYINITLIST(GLOB.round_end_notifiees)
-	GLOB.round_end_notifiees["<@[sender.mention]>"] = TRUE
+	GLOB.round_end_notifiees[sender.mention] = TRUE
 	return "I will notify <@[sender.mention]> when the round ends."
 
 /datum/tgs_chat_command/sdql

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -85,7 +85,7 @@ GLOBAL_LIST(round_end_notifiees)
 		return "[sender.mention], the round has already ended!"
 	LAZYINITLIST(GLOB.round_end_notifiees)
 	GLOB.round_end_notifiees[sender.mention] = TRUE
-	return "I will notify <@[sender.mention]> when the round ends."
+	return "I will notify [sender.mention] when the round ends."
 
 /datum/tgs_chat_command/sdql
 	name = "sdql"


### PR DESCRIPTION
[Changelogs]: changes made to DMAPI/tgs4 mean we no longer have to fill in the gaps with chat command sender's IDs I guess.

:cl: Phi
fix: no more <@@mention> stuff.
/:cl:

[why]: fixy fix fix.
