### PR TITLE
Now we can laugh at the first person to die everywhere. Also spelling fixes I guess.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -562,6 +562,13 @@ SUBSYSTEM_DEF(ticker)
 		if(SHUTTLE_HIJACK)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [station_name()] had its navigation protocols corrupted and went off course, but was recovered shortly after."
 
+	if(SSblackbox.first_death)
+		var/list/ded = SSblackbox.first_death
+		if(ded.len)
+			news_message += " A partial recovery of the station black box revealed the tragic last moments of a crew member. Their name was: [ded["name"]], [ded["role"]], at [ded["area"]].[ded["last_words"] ? " Their last words were: \"[ded["last_words"]]\"" : ""] May they rest in peace."
+		else
+			news_message += " A partial recovery of the station black box revealed that nobody died during the shift!"
+
 	if(news_message)
 		send2otherserver(news_source, news_message,"News_Report")
 		return news_message

--- a/code/modules/photography/camera/other.dm
+++ b/code/modules/photography/camera/other.dm
@@ -15,7 +15,7 @@
 
 /obj/item/camera/spooky/family
 	name = "fancy camera"
-	desc = "A fancy camera that has the latest magnifier mods and double the film load! With a complex double lens set with holy water to be able to see the dead, at laest to the Chaplain..."
+	desc = "A fancy camera that has the latest magnifier mods and double the film load! With a complex double lens set with holy water capable of seeing the dead, if you're in tune with spirit that is..."
 	see_ghosts = CAMERA_SEE_GHOSTS_ORBIT
 	pictures_max = 30
 	pictures_left = 30


### PR DESCRIPTION
[Changelogs]: Adds last words to the round end notification text, also fixes a spelling error on an item

:cl: Phi
add: Last words added to round end notification
fix: spelling error on the chaplain's special camera
/:cl:

[why]: Now people in discord get to point and laugh at the person who died to the clown's lube > airlock slide. Fixing spelling errors is good, too.
