### PR TITLE
Beepsky Smash requires quadruple sec instead of whiskey because wow

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -153,7 +153,7 @@
 	name = "Beepksy Smash"
 	id = "beepksysmash"
 	results = list("beepskysmash" = 4)
-	required_reagents = list("limejuice" = 2, "whiskey" = 2, "iron" = 1)
+	required_reagents = list("limejuice" = 2, "quadruple_sec" = 2, "iron" = 1)
 
 /datum/chemical_reaction/doctor_delight
 	name = "The Doctor's Delight"


### PR DESCRIPTION
[Changelogs]: Who changed it to whiskey? That's dumb.

:cl: Phi
tweak: Beepsky Smash recipe is correct again.
/:cl:

[why]: the recipe book states that quadruple sec is required, when it was whiskey for some odd reason.
