### PR TITLE
Xenobiology Console Camera Speed Fix

### DIFF
--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -3,6 +3,9 @@
 	visible_icon = 1
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "camera_target"
+	sprint = 1
+	var/max_sprint = 2
+	acceleration = 0
 	var/allowed_area = null
 
 /mob/camera/aiEye/remote/xenobio/Initialize()


### PR DESCRIPTION
[cl] Hunnewle
[tweak]Adjusted move speed of the Xenobiolgy's Console's Camera.
[/cl]

fix: Added three additional lines giving the camera 'eye' it's own variables rather than it using it's parents' variables.

[why]: One cannot properly work with slimes if one's point of view is moving at mach two.