### PR TITLE
fuck electrical storms

### DIFF
--- a/modular_shadow/code/modules/events/electrical_storm.dm
+++ b/modular_shadow/code/modules/events/electrical_storm.dm
@@ -1,2 +1,2 @@
 /datum/round_event_control/electrical_storm
-	max_occurrences = 2
+	max_occurrences = 3

--- a/modular_shadow/code/modules/events/electrical_storm.dm
+++ b/modular_shadow/code/modules/events/electrical_storm.dm
@@ -1,0 +1,2 @@
+/datum/round_event_control/electrical_storm
+	max_occurrences = 2

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3027,4 +3027,5 @@
 #include "modular_citadel\code\modules\vore\eating\vorepanel_vr.dm"
 #include "modular_citadel\interface\skin.dmf"
 #include "modular_shadow\code\game\objects\items\cards_ids.dm"
+#include "modular_shadow\code\modules\events\electrical_storm.dm"
 // END_INCLUDE


### PR DESCRIPTION
Seriously, fuck you. Why the fuck does it has a fucking weight of 40? That event does nothing to advance the round except being a pain in the ass. Who would've thought making the weight FUCKING 40 was a good fucking idea? Holy shit that even does litterally nothing except being unconvenient as fuck and making the janitor feel useful (except there's slaughter demons for that shit)

:cl:
tweak: Electrical storms now cannot happen more than twice per round
/:cl: