### PR TITLE
Fixes issue #98 - Sprite error in atmospheric firefighting helmet

### DIFF
--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -84,4 +84,3 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	cold_protection = HEAD
 	min_cold_protection_temperature = FIRE_HELM_MIN_TEMP_PROTECT
-	mutantrace_variation = MUTANTRACE_VARIATION


### PR DESCRIPTION
[Changelogs]: MUTANTRACE_VARIATION is not set or required for this hardhat, fixes https://github.com/ShadowStation/ShadowStation/issues/98

:cl: Phi
fix: Fixes a bug with hardhat_atmos that would make the sprite always face east while toggled off.
/:cl:

[why]: Bug fixy. MUTANTRACE_VARIATION is not set or required for this hardhat as it is unset.
