### PR TITLE
Adds back sugarcane to megaseed vendors

### DIFF
--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -31,6 +31,7 @@
 					/obj/item/seeds/replicapod = 3,
 					/obj/item/seeds/wheat/rice = 3,
 					/obj/item/seeds/soya = 3,
+					/obj/item/seeds/sugarcane = 3,
 					/obj/item/seeds/sunflower = 3,
 					/obj/item/seeds/tea = 3,
 					/obj/item/seeds/tobacco = 3,


### PR DESCRIPTION
[Changelogs]: Not entirely sure where these seeds went but now they're back.

:cl: Phi
fix: Sugarcane is back on the menu
/:cl:

[why]: sweet.
