### PR TITLE
Fixes invisible Augment Manipulators

### DIFF
--- a/code/game/machinery/aug_manipulator.dm
+++ b/code/game/machinery/aug_manipulator.dm
@@ -2,7 +2,7 @@
 	name = "\improper augment manipulator"
 	desc = "A machine for custom fitting augmentations, with in-built spraypainter."
 	icon = 'modular_shadow/icons/obj/robotics.dmi'
-	icon_state = "pdapainter"
+	icon_state = "robocolorer"
 	density = TRUE
 	obj_integrity = 200
 	max_integrity = 200


### PR DESCRIPTION
[Changelogs]: 

:cl: Phi
fix: Aug manipulators are no longer invisible
/:cl:

[why]: Bug fix. Due to a naming error in icon state aug manipulators were invisible.
