### PR TITLE
Fixes wallets turning invisible after inserting IDs

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -60,7 +60,7 @@
 /obj/item/storage/wallet/update_icon()
 	var/new_state = "wallet"
 	if(front_id)
-		new_state = "wallet_[front_id.icon_state]"
+		new_state = "wallet_id"
 	if(new_state != icon_state)		//avoid so many icon state changes.
 		icon_state = new_state
 


### PR DESCRIPTION
[Changelogs]: The introduction of our new pretty IDs broke the fuck out of the wallet, making it turn invisible upon inserting an ID. So instead of being smart, we revert to being dumb and display wallet_id when any kind of ID is inserted. No special checks.

Maybe later down the line this can be improved upon by making wallet icons for each ID type. This'll do for now though.

:cl: Phi
fix: Fixed wallets turning invisible upon inserting IDs into them.
/:cl:

[why]: bug fixy.
