### PR TITLE
Ports /tg/'s birthday cake recipe, including caramel

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -76,6 +76,22 @@
 	required_reagents = list("corn_starch" = 1, "sacid" = 1)
 	required_temp = 374
 
+/datum/chemical_reaction/caramel
+	name = "Caramel"
+	id = /datum/reagent/consumable/caramel
+	results = list(/datum/reagent/consumable/caramel = 1)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1)
+	required_temp = 413.15
+	mob_react = FALSE
+
+/datum/chemical_reaction/caramel_burned
+	name = "Caramel burned"
+	id = "caramel_burned"
+	results = list(/datum/reagent/carbon = 1)
+	required_reagents = list(/datum/reagent/consumable/caramel = 1)
+	required_temp = 483.15
+	mob_react = FALSE
+
 /datum/chemical_reaction/cheesewheel
 	name = "Cheesewheel"
 	id = "cheesewheel"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -69,8 +69,10 @@
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
 	reqs = list(
-		/obj/item/clothing/head/hardhat/cakehat = 1,
-		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
+		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
+		/obj/item/candle = 1,
+		/datum/reagent/consumable/sugar = 5,
+		/datum/reagent/consumable/caramel = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	subcategory = CAT_CAKE

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -756,3 +756,12 @@
 	quality = FOOD_FANTASTIC
 	taste_mult = 100
 	can_synth = FALSE
+
+/datum/reagent/consumable/caramel
+	name = "Caramel"
+	description = "Who would have guessed that heating sugar is so delicious?"
+	nutriment_factor = 10 * REAGENTS_METABOLISM
+	color = "#D98736"
+	taste_mult = 2
+	taste_description = "caramel"
+	reagent_state = SOLID


### PR DESCRIPTION
[Changelogs]: 

:cl: Phi
add: Added caramel and burnt caramel reagents
tweak: Tweaked birthday cake recipe to require caramel and candles instead of a cakehat.
/:cl:

[why]: People were getting confused as to why they couldn't craft birthday cakes, because the pre-existing recipe called for a cake hat (why).

Closes https://github.com/ShadowStation/ShadowStation/issues/115