### PR TITLE
Admin revive clears suicide status

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -804,6 +804,7 @@
 		if(D.severity != DISEASE_SEVERITY_POSITIVE)
 			D.cure(FALSE)
 	if(admin_revive)
+		suiciding = FALSE
 		regenerate_limbs()
 		regenerate_organs()
 		handcuffed = initial(handcuffed)


### PR DESCRIPTION
[Changelogs]: Ports #46050 from tg.

This PR makes admin revives set the mob's `suiciding` var to FALSE. The regular fully_revive() proc is unaffected.

:cl: Denton
admin: Admin revives now set the mob's suiciding var to FALSE.
/:cl:

[why]: This makes it easier for admins to bring suicided players back into the game, like when someone suicides instead of letting an admin offer their body to ghosts.
