### PR TITLE
Adds DNR trait

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -315,3 +315,10 @@
 	if(quirk_holder.mind && LAZYLEN(quirk_holder.mind.antag_datums))
 		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused your voice to be heard.</span>")
 		qdel(src)
+
+/datum/quirk/noclone
+	name = "DNR"
+	desc = "You have filed a Do Not Resuscitate order, meaning that no matter how hard medical staff try you cannot be revived or cloned upon death."
+	value = -3
+	mob_trait = TRAIT_NOCLONE
+	medical_record_text = "Patient has a DNR (Do not resuscitate) order on file, and cannot be revived or cloned upon death."

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -322,3 +322,7 @@
 	value = -3
 	mob_trait = TRAIT_NOCLONE
 	medical_record_text = "Patient has a DNR (Do not resuscitate) order on file, and cannot be revived or cloned upon death."
+
+/datum/quirk/noclone/add()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(TRAIT_NOCLONE, TRAUMA_RESILIENCE_ABSOLUTE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the DNR (Do not resuscitate) trait. Players who pick this trait will not be able to be revived or cloned if they die.

## Why It's Good For The Game

People asked for this trait, gives players the chance to live dangerously. There's no coming back if you die.

## Changelog
:cl: Phi
add: Added DNR trait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
