### PR TITLE
Tweaks DNR, and adds DNC trait

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -74,8 +74,8 @@
 #define TRAIT_MASO              "masochism"
 #define TRAIT_EMPATH			"empath"
 #define TRAIT_FRIENDLY			"friendly"
-
 #define TRAIT_EXCITABLE			"excitable"
+#define TRAIT_NEVER_CLONE		"never_clone"
 
 // common trait sources
 #define TRAIT_GENERIC "generic"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -316,13 +316,13 @@
 		to_chat(quirk_holder, "<span class='boldannounce'>Your antagonistic nature has caused your voice to be heard.</span>")
 		qdel(src)
 
-/datum/quirk/noclone
+/datum/quirk/norevive
 	name = "DNR"
 	desc = "You have filed a Do Not Resuscitate order, meaning that no matter how hard medical staff try you cannot be revived or cloned upon death."
 	value = -3
 	mob_trait = TRAIT_NOCLONE
 	medical_record_text = "Patient has a DNR (Do not resuscitate) order on file, and cannot be revived or cloned upon death."
 
-/datum/quirk/noclone/add()
+/datum/quirk/norevive/add()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.gain_trauma(TRAIT_NOCLONE, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -102,3 +102,10 @@
 	gain_text = "<span class='notice'>Your tail wags slighthly at the thought of headpats!</span>"
 	lose_text = "<span class='notice'>You regain your composure.</span>"
 	medical_record_text = "Patient exhibits an unusual excitement at the thought of having their head pet by another."
+
+/datum/quirk/noclone
+	name = "DNC"
+	desc = "You have filed a Do Not Clone order, stating that you do not wish to be cloned. You can still be revived by other means."
+	value = 0
+	mob_trait = TRAIT_NEVER_CLONE
+	medical_record_text = "Patient has a DNC (Do not clone) order on file, and cannot be cloned as a result."

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -442,6 +442,10 @@
 		var/mob/living/brain/B = mob_occupant
 		dna = B.stored_dna
 
+	if(mob_occupant.has_trait(TRAIT_NEVER_CLONE))
+		scantemp = "<font class='bad'>Subject has an active DNC record on file. Unable to clone.</font>"
+		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
+		return
 	if(!istype(dna))
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
@@ -451,7 +455,7 @@
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
 	if((mob_occupant.has_trait(TRAIT_NOCLONE)) && (src.scanner.scan_level < 2))
-		scantemp = "<font class='bad'>Subject no longer contains the fundamental materials required to create a living clone.</font>"
+		scantemp = "<font class='bad'>Subject either has a DNR record on file or no longer contains the fundamental materials required to create a living clone.</font>"
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
 		return
 	if ((!mob_occupant.ckey) || (!mob_occupant.client))

--- a/code/game/machinery/exp_cloner.dm
+++ b/code/game/machinery/exp_cloner.dm
@@ -264,12 +264,16 @@
 		var/mob/living/brain/B = mob_occupant
 		dna = B.stored_dna
 
+	if(mob_occupant.has_trait(TRAIT_NEVER_CLONE))
+		scantemp = "<font class='bad'>Subject has an active DNC record on file. Unable to clone.</font>"
+		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
+		return
 	if(!istype(dna))
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
 	if((mob_occupant.has_trait(TRAIT_NOCLONE)) && (src.scanner.scan_level < 2))
-		scantemp = "<font class='bad'>Subject no longer contains the fundamental materials required to create a living clone.</font>"
+		scantemp = "<font class='bad'>Subject either has a DNR record on file or no longer contains the fundamental materials required to create a living clone.</font>"
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Tweaks DNR perk's internal naming and adds the DNC (Do not clone) trait. This was a requested feature that allows players to state that they do not wish to be cloned. They can still be revived through surgeries and alternate treatments.

This trait is neutral, and is intended solely for RP value. 

## Why It's Good For The Game

Gives players more RP options and ~~forces~~ gives medical staff more of a challenge as they can't just throw people into the cloner to revive them. 

## Changelog
:cl: Phi
add: Added the DNC trait.
tweak: Tweaked the DNR trait's internal naming
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
