### PR TITLE
Change to Cold Resistance to Space Adapt

### DIFF
--- a/code/datums/mutations/cold_resistance.dm
+++ b/code/datums/mutations/cold_resistance.dm
@@ -18,13 +18,13 @@
 	if(..())
 		return
 	owner.add_trait(TRAIT_RESISTCOLD, "cold_resistance")
-//	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")  CITADEL CHANGE
+	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.remove_trait(TRAIT_RESISTCOLD, "cold_resistance")
-//	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")   CITADEL CHANGE
+	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_life(mob/living/carbon/human/owner)
 	if(owner.getFireLoss())


### PR DESCRIPTION
## About The Pull Request

Commented the Low Pressure Resist Trait back into the Cold Resistance mutation.

## Why It's Good For The Game

Cold Resistance on its own was kind of useless.  You still needed a space suit outside the station to deal with pressure which generally had cold resist anyway.  There were only one or two places inside the station that were cold.

## Changelog
:cl:
tweak: Removed the comment flags around the code
/:cl:
