### PR TITLE
Heart attacks can happen...

### DIFF
--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/heart_attack
 	weight = 20
 	max_occurrences = 2
-	min_players = 40 // To avoid shafting lowpop
+	min_players = 20 //can be raised to 25 if it shown to cause more issues.
 
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()


### PR DESCRIPTION


## About The Pull Request

Changed the Pop requirements for the Heart Attack station event from 40 to 20, subject to change if it becomes a real problem

## Why It's Good For The Game

Heart attack pop rate was stupid high for the reason that it could screw over lower pops.  Meanwhile, the Rod, meteors and other, much worse things had a much lower pop requirement.  Bringing it down so it might happen and give medical something to do.

## Changelog
:cl:
balance: Pop requirements changed from 40 to 20
/:cl:

