### PR TITLE
Removes checks for devourable flags for sec-hounds

### DIFF
--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -450,9 +450,6 @@
 		return
 	if(iscarbon(target))
 		var/mob/living/carbon/brigman = target
-		if (!brigman.devourable)
-			to_chat(user, "The target registers an error code. Unable to insert into [src].")
-			return
 		if(patient)
 			to_chat(user,"<span class='warning'>Your [src] is already occupied.</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Been meaning to do this one for a while. Currently, medihounds can just straight up sleeper someone and bypass devourable settings. sechounds cannot brig someone with devourable off, though. This PR fixes that.

Note: This does not give secborg players a licence to just belly brig anyone, they'd need to be ordered to do so like normal.

## Why It's Good For The Game

Sechounds are pretty useless when they get pref-blocked and can't use their belly brigs. Now they can use it regardless of the devourable pref.

## Changelog
:cl:
tweak: K9-borgs can use their belly brig on anyone regardless of devourable preference.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
