### PR TITLE
Kinkmate addition and fix

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -27,11 +27,11 @@
 					/obj/item/storage/hypospraykit/o2 = 2,
 					/obj/item/storage/hypospraykit/brute = 2,
 					/obj/item/reagent_containers/glass/bottle/vial/small = 5)
-					
+
 /obj/machinery/vending/wardrobe/chap_wardrobe
 	premium = list(/obj/item/toy/plush/plushvar = 1,
 					/obj/item/toy/plush/narplush = 1)
-	
+
 #define STANDARD_CHARGE 1
 #define CONTRABAND_CHARGE 2
 #define COIN_CHARGE 3
@@ -53,11 +53,16 @@
 	contraband = list(/obj/item/restraints/handcuffs/fake/kinky = 5,
 				/obj/item/clothing/neck/petcollar = 5,
 				/obj/item/clothing/under/mankini = 1,
-				/obj/item/dildo/flared/huge = 1
+				/obj/item/dildo/flared/huge = 1,
+				/obj/item/clothing/mask/muzzle = 2
 				)
 	premium = list(
 				/obj/item/electropack/shockcollar = 3,
-				/obj/item/clothing/neck/petcollar/locked = 1
+				/obj/item/clothing/neck/petcollar/locked = 1,
+				/obj/item/clothing/under/schoolgirl/locked/red = 1,
+				/obj/item/clothing/under/schoolgirl/locked/orange = 1,
+				/obj/item/clothing/under/schoolgirl/locked/green = 1,
+				/obj/item/clothing/under/schoolgirl/locked = 1
 				)
 	refill_canister = /obj/item/vending_refill/kink
 /*

--- a/modular_shadow/code/game/machinery/vending.dm
+++ b/modular_shadow/code/game/machinery/vending.dm
@@ -1,9 +1,0 @@
-/obj/machinery/vending/kink
-	premium = list(
-				/obj/item/electropack/shockcollar = 3,
-				/obj/item/clothing/neck/petcollar/locked = 1,
-				/obj/item/clothing/under/schoolgirl/locked/red = 1,
-				/obj/item/clothing/under/schoolgirl/locked/orange = 1,
-				/obj/item/clothing/under/schoolgirl/locked/green = 1,
-				/obj/item/clothing/under/schoolgirl/locked = 1
-				)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3029,7 +3029,6 @@
 #include "modular_citadel\code\modules\vore\eating\voreitems.dm"
 #include "modular_citadel\code\modules\vore\eating\vorepanel_vr.dm"
 #include "modular_citadel\interface\skin.dmf"
-#include "modular_shadow\code\game\machinery\vending.dm"
 #include "modular_shadow\code\game\objects\items\cards_ids.dm"
 #include "modular_shadow\code\modules\admin\admin.dm"
 #include "modular_shadow\code\modules\clothing\under\schoolgirl.dm"


### PR DESCRIPTION
## About The Pull Request
Adds 2 muzzles to the Kinkmate contraband list.  Merged the Kinkmate file from modular shadow and smashed it in with the modular citadel one because having two was stupid.  Removed the folder "machinery" and the file "vending" from modular shadow (Which is why the tg file is in this update.)
Compiled and tested, all good and working as intended.

## Why It's Good For The Game
Muzzles were suggested and keeping the code concise is always good.

## Changelog
:cl:
add: 2 Muzzles to Kinkmate
del: Deleated Machinery folder and vending file from modular shadow
tweak: Merged the vending file from modular shadow with the vending in modular citadel
/:cl:
