### PR TITLE
Removes the antag drafting system

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -260,14 +260,14 @@ SUBSYSTEM_DEF(ticker)
 		message_admins("<span class='notice'>DEBUG: Bypassing prestart checks...</span>")
 
 	CHECK_TICK
-	/*if(hide_mode) CIT CHANGE - comments this section out to obfuscate gamemodes. Quit self-antagging during extended just because "hurrrrr no antaggs!!!!!! i giv sec thing 2 do!!!!!!!!!" it's bullshit and everyone hates it
+	if(hide_mode)
 		var/list/modes = new
 		for (var/datum/game_mode/M in runnable_modes)
 			modes += M.name
 		modes = sortList(modes)
 		to_chat(world, "<b>The gamemode is: secret!\nPossibilities:</B> [english_list(modes)]")
 	else
-		mode.announce()*/
+		mode.announce()
 
 	if(!CONFIG_GET(flag/ooc_during_round))
 		toggle_ooc(FALSE) // Turn it off

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -350,8 +350,8 @@
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
 	var/list/candidates = list()
-	var/list/drafted = list()
-	var/datum/mind/applicant = null
+	//var/list/drafted = list() !!REMOVING DRAFTING!!
+	//var/datum/mind/applicant = null !!REMOVING DRAFTING!!
 
 	// Ultimate randomizing code right here
 	for(var/mob/dead/new_player/player in GLOB.player_list)
@@ -375,6 +375,7 @@
 				if(player.assigned_role == job)
 					candidates -= player
 
+	/* Results from a poll dictate that antag drafting is going away. Bye antag drafting!
 	if(candidates.len < recommended_enemies)
 		for(var/mob/dead/new_player/player in players)
 			if(player.client && player.ready == PLAYER_READY_TO_PLAY)
@@ -417,6 +418,9 @@
 
 		else												// Not enough scrubs, ABORT ABORT ABORT
 			break
+*/
+
+	candidates = shuffle(candidates) // Lets shuffle, just one last time
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than recommended_enemies
 							//			recommended_enemies if the number of people with that role set to yes is less than recomended_enemies,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Following the results of the poll located [here](https://forum.shadow-station.com/d/23-antag-picking-drafting-tweaks), the antag picking system will now only pick people who have antag enabled in their preferences if a gamemode that requires antags is picked.

## Why It's Good For The Game

People wanted it, I suspect that this will cause more issues than it'll fix. But we'll see.

Note: If you pick secret and don't have antag enabled yourself, you're part of the problem. Do not vote for secret if you yourself do not want to play as an antag. This will result in the game not being able to start.

## Changelog
:cl:
tweak: Removed the antag drafting system.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
