### PR TITLE
Introduces Sigmar's maint bar

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -39271,11 +39271,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/science/test_area)
-"bOK" = (
-/obj/structure/barricade/wooden,
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bOL" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel,
@@ -39848,10 +39843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"bPU" = (
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bPV" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maint Bar Access";
@@ -39864,22 +39855,6 @@
 /area/maintenance/port/aft)
 "bPW" = (
 /obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPX" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPY" = (
-/obj/structure/girder,
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bPZ" = (
-/obj/structure/chair{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bQa" = (
@@ -40277,20 +40252,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bRg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/carpet/black,
+/area/maintenance/bar)
 "bRh" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/carpet,
+/area/maintenance/bar)
 "bRi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -41630,12 +41605,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bUt" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bUu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41643,19 +41612,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bUv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bUx" = (
@@ -42139,8 +42098,8 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/closed/wall,
+/area/maintenance/bar)
 "bVI" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -44089,7 +44048,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/closed/wall,
+/turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cas" = (
 /obj/machinery/door/airlock/maintenance{
@@ -47828,11 +47787,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cjn" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
+/obj/structure/chair/wood/normal,
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/effect/landmark/blobstart,
-/turf/open/floor/wood,
 /area/maintenance/bar)
 "cjo" = (
 /obj/structure/closet/toolcloset,
@@ -56350,6 +56308,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"dqN" = (
+/obj/structure/chair/stool/bar,
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "dvc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -56385,6 +56348,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"dSG" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "eaI" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom{
@@ -56436,6 +56403,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"eNB" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eRz" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -56494,10 +56465,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
 "fxa" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
+/obj/structure/chair/wood/normal{
+	dir = 8
 	},
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "fGf" = (
 /obj/machinery/smartfridge/disks{
@@ -56539,6 +56510,10 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"gdV" = (
+/obj/machinery/vending/snack/random,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "gfD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56560,6 +56535,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"guD" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/carpet,
+/area/maintenance/bar)
 "gwd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56572,6 +56552,14 @@
 	},
 /turf/closed/wall,
 /area/security/vacantoffice)
+"gzu" = (
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/maintenance/port/aft)
 "gBo" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -56630,6 +56618,13 @@
 	dir = 8
 	},
 /area/medical/sleeper)
+"hbj" = (
+/obj/machinery/vending/clothing,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "hcE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
@@ -56652,6 +56647,16 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"hAM" = (
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/light,
+/area/maintenance/bar)
 "hRa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -56700,13 +56705,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"izv" = (
-/obj/machinery/vending/clothing,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -56736,6 +56734,19 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
+"iQE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"iUU" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/maintenance/bar)
 "iVU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56744,6 +56755,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
+"iXf" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "jbf" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -56781,12 +56796,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "jqv" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/wood,
 /area/maintenance/bar)
 "jrE" = (
 /obj/structure/sign/poster/official/random{
@@ -56823,13 +56838,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jJF" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/maintenance/port/aft)
 "jMY" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -56855,6 +56863,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"jUL" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plating,
+/area/maintenance/bar)
 "jVl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56921,6 +56933,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"kHP" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/robot_debris/old,
+/turf/open/floor/light,
+/area/maintenance/bar)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -56952,12 +56971,15 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
 "lnu" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
+/area/maintenance/bar)
+"lyc" = (
+/obj/machinery/atmospherics/pipe/simple/dark/visible,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/light,
 /area/maintenance/bar)
 "lzL" = (
 /obj/structure/table/wood,
@@ -56989,10 +57011,8 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "mpI" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/light,
 /area/maintenance/bar)
 "mqZ" = (
 /obj/structure/reagent_dispensers/keg/aphro/strong,
@@ -57001,6 +57021,7 @@
 /area/maintenance/bar)
 "mrR" = (
 /obj/effect/spawner/lootdrop/keg,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "muz" = (
@@ -57024,6 +57045,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"mEV" = (
+/obj/structure/table/wood,
+/obj/item/soap,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"mLP" = (
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/light,
+/area/maintenance/bar)
+"mMv" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/black,
+/area/maintenance/bar)
 "mNi" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
@@ -57031,11 +57068,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"mPE" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "mRe" = (
 /obj/machinery/light{
 	dir = 8
@@ -57048,14 +57080,25 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
-"nfm" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/maintenance/bar)
+"nif" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "noK" = (
 /obj/structure/girder,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"nuS" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nxv" = (
 /obj/machinery/power/apc{
 	name = "Construction Area APC";
@@ -57126,11 +57169,10 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "oKh" = (
-/obj/structure/chair/wood/normal{
-	icon_state = "wooden_chair";
-	dir = 8
+/obj/structure/window{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/light,
 /area/maintenance/bar)
 "oUh" = (
 /obj/structure/disposalpipe/trunk{
@@ -57143,6 +57185,19 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
+"oWa" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/carpet/black,
+/area/maintenance/bar)
+"pkA" = (
+/obj/structure/dresser,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/maintenance/bar)
 "poc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -57152,6 +57207,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"pzL" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/rag{
+	pixel_x = 6
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 6;
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -57218,12 +57293,28 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
+"qxq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet,
+/area/maintenance/bar)
 "qIw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"qKd" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/bar)
+"qZq" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/bar)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57239,12 +57330,28 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rqv" = (
+/obj/structure/table,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/obj/item/stack/spacecash/c10,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rsp" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"rxD" = (
+/obj/machinery/door/window/southright{
+	icon_state = "right";
+	dir = 4
+	},
+/turf/open/floor/light,
+/area/maintenance/bar)
 "rBq" = (
 /obj/item/clothing/head/kitty,
 /obj/item/clothing/under/maid,
@@ -57342,6 +57449,13 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"sFY" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "sLv" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57364,10 +57478,6 @@
 "sQX" = (
 /turf/open/floor/plating,
 /area/space)
-"sRT" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "sSW" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
@@ -57391,10 +57501,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"sXA" = (
-/obj/machinery/vending/boozeomat/all_access,
-/turf/closed/wall,
-/area/maintenance/bar)
 "tal" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -57412,6 +57518,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "tkU" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -57459,30 +57569,12 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"tRF" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"uaw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/storage/art";
-	dir = 1;
-	name = "Maint bar";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "udp" = (
 /obj/item/crowbar/large,
 /obj/structure/rack,
@@ -57505,6 +57597,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"unc" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "uoB" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -57516,9 +57616,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "usO" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/vending/cola/random,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -57527,15 +57627,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"uuG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "uvZ" = (
 /obj/structure/mineral_door/wood,
 /turf/open/floor/wood,
@@ -57544,6 +57635,13 @@
 /obj/machinery/food_cart,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"uKR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light_switch{
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "uNu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57646,12 +57744,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"vzO" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "vzV" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
@@ -57687,10 +57779,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vQC" = (
+/obj/structure/mineral_door/wood,
+/obj/effect/decal/cleanable/oil/slippery,
+/turf/open/floor/wood,
+/area/maintenance/bar)
 "wfR" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
 /turf/open/floor/plating,
+/area/maintenance/bar)
+"wgW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
 /area/maintenance/bar)
 "wiV" = (
 /obj/item/twohanded/required/kirbyplants/random,
@@ -57755,13 +57856,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"wIh" = (
+/turf/open/floor/carpet/black,
+/area/maintenance/bar)
 "wUY" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "xgF" = (
-/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -57786,6 +57890,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
+"xwX" = (
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/light,
+/area/maintenance/bar)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -57834,6 +57947,14 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/security/vacantoffice)
+"ykY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 
 (1,1,1) = {"
 aaa
@@ -77782,8 +77903,8 @@ aaa
 aaa
 bCq
 bHE
-bPW
 bHE
+bSo
 bHE
 bCq
 bVB
@@ -78038,10 +78159,10 @@ aaa
 aaa
 aaa
 bCq
-bHE
-bHE
-bSo
-bHE
+bPV
+bCq
+bCq
+cOw
 bCq
 bVA
 bWw
@@ -78295,10 +78416,10 @@ aaa
 aaa
 aaa
 bCq
-bPV
-bCq
-bCq
-cTF
+bHE
+bHE
+eNB
+bHE
 bCq
 bVD
 bWy
@@ -78550,12 +78671,12 @@ bJb
 bGi
 bGi
 aoV
-aoV
 bCq
-bPU
-bHE
-bSp
-bHE
+bCq
+bPW
+eNB
+rqv
+eNB
 bCq
 bVC
 bWx
@@ -78807,12 +78928,12 @@ byE
 bKk
 bGi
 aoV
-aoV
 bCq
-bPW
-bCq
-bCq
-cOw
+bHE
+bHE
+bHE
+eNB
+bHE
 bCq
 bVF
 bWA
@@ -79064,10 +79185,10 @@ byE
 bKj
 bGi
 aoV
-aoV
 bCq
 bHE
 bHE
+cqL
 bSq
 cdb
 bCq
@@ -79321,25 +79442,25 @@ bJd
 bKm
 bxy
 aaf
-aaf
 bCq
-bPY
-cOw
-bCq
-bCq
-bCq
-bCq
-bCq
+nuS
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
 bYy
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
-bCq
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
 bUs
 bLv
 aaa
@@ -79578,25 +79699,25 @@ bHA
 bKl
 bxy
 aaH
-aaH
-bCq
-bPX
-bRg
-bRg
 bCq
 bHE
+dKP
+bRg
+oWa
+dKP
+pzL
 bVG
-bHE
-bHE
-bCq
+jUL
+sEt
+unc
 tPT
-tRF
+dfL
 mrR
 dKP
 odx
 rBq
 tur
-bCq
+dKP
 bUs
 bLv
 aaa
@@ -79835,25 +79956,25 @@ byE
 byE
 bGi
 aaf
-aaf
 bLv
-bQa
 bHE
-bHE
-bCq
-bHE
-bCq
-bCq
-bCq
-sXA
-mPE
+dKP
+mMv
+wIh
+uvZ
+qKd
+dKP
+iiW
+uKR
+dSG
+iiW
 kyF
 sAM
 imH
 evR
 qhs
 rMN
-bCq
+dKP
 bUs
 bLv
 aaf
@@ -80092,25 +80213,25 @@ bGM
 bKn
 bGi
 aoV
-aoV
 bLv
-bPZ
 bHE
-bHE
-cTF
-bHE
-bCq
-iiW
-iiW
-iiW
-iiW
-iiW
-dfL
+dKP
+dKP
+dKP
+dKP
+iQE
+dKP
+vQC
+dKP
+vjm
+bcU
+bcU
+bcU
 dKP
 mqZ
 tyO
 wfR
-bCq
+dKP
 bUs
 bLv
 aaa
@@ -80349,25 +80470,25 @@ byE
 bKp
 bGi
 aaf
-aaf
 bLv
 bHE
-bHE
-bSs
-bCq
-bHE
-bCq
+dKP
+guD
+qxq
 uvZ
+sAM
+dSG
+dSG
+iiW
+dKV
+dKV
+dKV
+dqN
 dKP
-vjm
-bcU
-bcU
-bcU
 dKP
 dKP
 dKP
 dKP
-bCq
 bUs
 bLv
 aaa
@@ -80606,25 +80727,25 @@ byE
 bKo
 bxy
 aaH
-aaH
 bCq
 bHE
+dKP
 bRh
-bLu
-bCq
-bHE
-bCq
+pkA
+dKP
+hbj
+gdV
 iiW
+iXf
 iiW
-dKV
 xgF
-dKV
-dKV
 iiW
-gMl
-gMl
 iiW
-bLv
+iiW
+iiW
+sAM
+dKP
+bHE
 bUs
 bLv
 aaf
@@ -80863,25 +80984,25 @@ bGn
 bKq
 bxy
 aaf
-aaf
 bCq
-bOK
-bCq
-bCq
-bCq
-bUt
-bCq
-uaw
+bSp
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
+dKP
 tkU
-iiW
+gMl
 lnu
 cjn
-iiW
-cxo
-bcU
-bcU
-vzO
-bLv
+mEV
+xwX
+mLP
+kHP
+dKP
+bHE
 bUs
 bLv
 aaa
@@ -81120,25 +81241,25 @@ bxy
 bxy
 bxy
 bLv
-bLv
 bCq
 bHE
-bLv
-aaa
-bLv
-uuG
-jJF
+bHE
+bHE
+bHE
+bHE
+bHE
+cAh
+gzu
 gBo
-sEt
+qZq
+iiW
 cxo
-bcU
-bcU
 jqv
-cxo
-bcU
+iUU
+lyc
 mpI
-vzO
-bLv
+dKP
+bHE
 bUs
 bLv
 aaa
@@ -81379,23 +81500,23 @@ bLu
 bHE
 bHE
 bHE
-bHE
-bLv
-aaf
-bLv
-bUs
 bCq
-iiW
+bLv
+bLv
+bLv
+bCq
+bUs
+dKP
 iiW
 fxa
-bcU
-bcU
-vzO
 iiW
+cxo
+bcU
+hAM
 oKh
-oKh
-iiW
-bLv
+rxD
+dKP
+bHE
 bUs
 bLv
 aaf
@@ -81637,22 +81758,22 @@ bLv
 bLv
 bHE
 bLv
+gXs
+gXs
+gXs
 bCq
-aaa
-bLv
 bUs
-bCq
-sRT
+dKP
 usO
+sFY
 iiW
-oKh
-oKh
+dSG
 iiW
+dSG
+xgF
 iiW
-iiW
-izv
-nfm
-bCq
+dKP
+bHE
 bUs
 bCq
 aaa
@@ -81894,21 +82015,21 @@ aaf
 bLv
 bHE
 bLv
-aaa
-aaa
+gXs
+gXs
 bTB
-bUv
 bES
-bES
-bES
-bES
-bGp
-bGp
-bGp
-bGp
-bES
-bES
-bES
+ykY
+wgW
+wgW
+wgW
+wgW
+wgW
+wgW
+wgW
+wgW
+wgW
+wgW
 car
 bUs
 bCq
@@ -82149,13 +82270,13 @@ bCq
 bLv
 bLv
 bLv
-bOK
-bLv
+nuS
+bCq
 bLv
 bLv
 bTA
 bUu
-bLw
+nif
 bLw
 bLw
 bLw


### PR DESCRIPTION
A new layout for the maintenance bar on Box courtesy of Sigmar#6197

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sigmar's redesign for the maintenance bar is to better suit Shadow Station's popcount and... intents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A nicer, slightly modified bar that will set us a step above the competition!
![image](https://user-images.githubusercontent.com/5308439/65367649-989d4600-dc02-11e9-894e-222326770daf.png)


## Changelog
:cl:
tweak: Boxstation maintenance bar updated and improved.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->Sigmar
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
